### PR TITLE
Fixing race condition on toFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,17 +92,16 @@ const handleSave = async (
   //handling image Options
   stream = prepareSharpStream(stream, imageOptions);
 
-  stream
+  await stream
     .toFile(path + "/" + filename, function (err) {
       if (err) console.log(err);
-    })
-    .on("finish", function () {
       console.log("done");
       cb(null, {
         filename: filename,
         path: path + "/" + filename,
       });
     });
+
   // finally
   file.stream.pipe(stream);
 };


### PR DESCRIPTION
Closes #6 

`cb()` is already called even before the `toFile(...)` operation is complete, because `on('finish', ...)` runs regardless of how `toFile` is being executed. 

This causes file r/w race when the user loads the image file as soon as the controller returns the filename. Precisely speaking, the image file is being read while the image file is being written to the upload folder, making the image returning an empty output or a truncated image.