### PR TITLE
feat: pass req into getFilename

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const newFilenameFunction = (og_filename, options) => {
 };
 ```
 
-If you want to use a request field to generate the filename, you can do it like this:
+If you want to use a request field called `metadata` passed in the body to generate the filename, you can do it like this:
 
 ```js
 const newFilenameFunction = (og_filename, options, req) => {

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ const newFilenameFunction = (og_filename, options, req) => {
 };
 ```
 
+Note that any other field present in the request body will work.
+
 Feel free to open a Issue for features or bug fixes
 
 Thanks

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ Small Utilty to use with Multer as storage engine to optimise images on the fly 
 
 ## Image Options
 
-| Key              | Option                                                 | Description                                                                                                                                                        |
-| ---------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| fileFormat       | `jpg / png/ webp 'Default:"jpg"`                       | Output file type                                                                                                                                                   |
-| resize           | `{height:"", widht:"",resizeMode:"" } 'Default:{}'`    | If provided Images will be resized before saving                                                                                                                   |
-| quality          | `Number(0-100) 'Default :80'`                          | Reduces the qulity for better performance                                                                                                                          |
-| useTimestamp     | `true/false 'Default :false'`(optional)                | Adds suffice to file name Ex: "Images_1653679779.jpg"                                                                                                              |
-| watermarkOptions | `{input:"", location:"",opacity:1-100} ` (optional)    | Adds watermark on every Images before Saving                                                                                                                       |
-| filename         | `(originalname,options) => return newname ` (optional) | Option to return a new name for saving file it will give you original name as first argument you must return a string with filename and extension like "image.png" |
+| Key              | Option                                                     | Description                                                                                                                                                        |
+| ---------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| fileFormat       | `jpg / png/ webp 'Default:"jpg"`                           | Output file type                                                                                                                                                   |
+| resize           | `{height:"", widht:"",resizeMode:"" } 'Default:{}'`        | If provided Images will be resized before saving                                                                                                                   |
+| quality          | `Number(0-100) 'Default :80'`                              | Reduces the qulity for better performance                                                                                                                          |
+| useTimestamp     | `true/false 'Default :false'`(optional)                    | Adds suffice to file name Ex: "Images_1653679779.jpg"                                                                                                              |
+| watermarkOptions | `{input:"", location:"",opacity:1-100} ` (optional)        | Adds watermark on every Images before Saving                                                                                                                       |
+| filename         | `(originalname,options,req) => return newname ` (optional) | Option to return a new name for saving file it will give you original name as first argument you must return a string with filename and extension like "image.png" |
 
 ### resizeMode
 
@@ -90,6 +90,14 @@ const newFilenameFunction = (og_filename, options) => {
     "." +
     options.fileFormat;
   return newname;
+};
+```
+
+If you want to use a request field to generate the filename, you can do it like this:
+
+```js
+const newFilenameFunction = (og_filename, options, req) => {
+  return `${og_filename}_${req.body.metadata}` + options.fileFormat;
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function MyCustomStorage(options) {
 MyCustomStorage.prototype._handleFile = function _handleFile(req, file, cb) {
   const imageOptions = this.imageOptions;
   const watermarkOptions = this.watermarkOptions;
-  const filename = this.getFilename(file.originalname, imageOptions);
+  const filename = this.getFilename(file.originalname, imageOptions, req);
   this.getDestination(req, file, function (err, path) {
     if (err) return cb(err);
     handleSave(req, file, cb, imageOptions, path, watermarkOptions, filename);


### PR DESCRIPTION
Pipes the request object into `getFilename` to allow using information passed in the body when generating the filename.